### PR TITLE
Add ban users for 2 likely spam messages within 7 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ ruff = "^0.1.11"
 exclude = [
     "src/app/bot.py", # Because of handlers import
     "src/handlers/commands.py", # Because of unused import (ADMIN_IDS)
+    "src/utils/spam_detection.py", # Because of timedelta import
     "**/__init__.py",
     ".bzr",
     ".direnv",


### PR DESCRIPTION
Что было сделано:
- Добавлена система отслеживания сообщений пользователей с временными метками
- Реализована логика бана за повторный спам (2 спам сообщения в течение 7 дней). Например, 0,0,1,0,1 -> бан (если между единицами менее 7 дней)
- Добавлено очищение буфера сообщений после бана или добавления в белый список

- Добавлены константы:
DAYS_WINDOW = 7 # порог дней для бана, если метка == likely spam шла 2 раза подряд за период n дней
N_LIKELY_SPAM_MESS = 2 # количество меток == likely spam, при котором будет бан за период n дней
MESSAGES_TO_WHITELIST = 3 # порог не спам сообщений для белого листа

-  Поправлен код добавления в белый список (3 последних не-спам сообщения), чтобы был возможен учет меток likely spam. Например, 0,1,0,0,0 -> добавление в белый список;
но если будет 0,1,0,1,0 и между единицами более 7 дней, то юзер не будет в бане и не будет в белом листе